### PR TITLE
feat: add CI workflow and golangci-lint configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOFLAGS: -mod=readonly
+
+jobs:
+  build-test-lint:
+    name: Build / Test / Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Go mod download
+        run: go mod download
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Fmt check
+        run: |
+          diff=$(gofmt -l . | grep -v vendor || true)
+          if [ -n "$diff" ]; then
+            echo "These files are not gofmt'd:" >&2
+            echo "$diff" >&2
+            exit 1
+          fi
+
+      - name: Run tests
+        run: go test -count=1 -timeout=5m ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m
+
+  docker:
+    name: Build & Push Docker Image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-test-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (multi-arch optional)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: lightin/peeng
+          tags: |
+            type=raw,value=latest
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest
+        run: echo "Image digest ${{ steps.build-and-push.outputs.digest }}"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+run:
+  timeout: 5m
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - gosimple
+    - ineffassign
+    - unused
+    - typecheck
+issues:
+  exclude-use-default: false
+  max-same-issues: 0
+  max-issues-per-linter: 0
+output:
+  sort-results: true


### PR DESCRIPTION
This pull request introduces a new CI pipeline and configures Go linting for the project. The main changes are the addition of a GitHub Actions workflow for continuous integration and a configuration file for `golangci-lint` to enforce code quality standards.

**Continuous Integration Setup:**

* Added `.github/workflows/ci.yml` to automate build, test, formatting checks, linting, and Docker image build/push on pull requests and pushes to `main`. This ensures code is always validated and Docker images are published for the main branch.

**Linting Configuration:**

* Added `.golangci.yml` to configure `golangci-lint` with enabled linters like `govet`, `errcheck`, and `staticcheck`, and set a 5-minute timeout for linting runs. This helps maintain code quality and catch common issues early.